### PR TITLE
Update UEFI version from v0.6 to v0.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target
+.cargo/
+target/
+
 Cargo.lock
-.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["no-std", "embedded", "hardware-support"]
 
 [dependencies]
 embedded-graphics = "0.6.2"
-uefi = "0.6.0"
+uefi = "0.8.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,11 @@ impl<'a, T: Into<Bgr888> + PixelColor> DrawTarget<T> for UefiDisplay<'a> {
         let Pixel(point, color) = item;
         let mut bytes = [0u8; 3];
         match self.info.pixel_format() {
-            PixelFormat::RGB => {
+            PixelFormat::Rgb => {
                 bytes
                     .copy_from_slice(&Rgb888::from(color.into()).into_storage().to_be_bytes()[1..]);
             }
-            PixelFormat::BGR => {
+            PixelFormat::Bgr => {
                 bytes.copy_from_slice(&color.into().into_storage().to_be_bytes()[1..]);
             }
             _ => return Err(Unsupported(())),


### PR DESCRIPTION
- Updated UEFI version from v0.6 to v0.8.1
- Rearranged .gitignore

UEFI v0.6 doesn't compile with a recent Rust compiler, and UEFI v0.9 just came out but also doesn't compile so I updated it to v0.8.1.

.gitignore was rearranged  so it's in alphabetical order with directories at the top and file[s] at the bottom